### PR TITLE
Implement `serde::{Serialize,Deserialize}`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 
 name = "intervallum"
-version = "1.4.2"
+version = "1.4.3"
 authors = [ "Pierre Talbot <pierre.talbot@uni.lu>" ]
 
 description = "Generic interval and interval set library."
-documentation = "https://docs.rs/intervallum/1.4.2/interval/"
+documentation = "https://docs.rs/intervallum/1.4.3/interval/"
 repository = "https://github.com/ptal/intervallum"
 readme = "README.md"
 keywords = ["interval", "math", "data-structure", "containers", "interval-set"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,7 @@ num-traits = "0.2.14"
 bit-set = "0.5.0"
 gcollections = "1.5.0"
 trilean = "1.1.0"
+serde = "1.0.219"
+
+[dev-dependencies]
+serde_test = "1.0.177"


### PR DESCRIPTION
Implement `serde::{Serialize,Deserialize}` for `Interval` and `IntervalSet`.
- `Interval` is represented as either a pair of numbers `(lower, upper)` or `None`
- `IntervalSet` is represented as a list of intervals
Extends #24 